### PR TITLE
[2/2] Fix InputDispatcher for some devices with a FOD (gestures)

### DIFF
--- a/build/soong/Android.bp
+++ b/build/soong/Android.bp
@@ -506,3 +506,19 @@ stagefright_qcom_legacy {
         },
     },
 }
+soong_config_module_type {
+    name: "inputdispatcher_skip_event_key",
+    module_type: "cc_defaults",
+    config_namespace: "lineageGlobalVars",
+    value_variables: ["target_inputdispatcher_skip_event_key"],
+    properties: ["cppflags"],
+}
+
+inputdispatcher_skip_event_key {
+    name: "inputdispatcher_skip_event_key_defaults",
+    soong_config_variables: {
+        target_inputdispatcher_skip_event_key: {
+            cppflags: ["-DINPUTDISPATCHER_SKIP_EVENT_KEY=%s"],
+        },
+    },
+}

--- a/config/BoardConfigSoong.mk
+++ b/config/BoardConfigSoong.mk
@@ -36,6 +36,7 @@ SOONG_CONFIG_lineageGlobalVars += \
     ignores_ftp_pptp_conntrack_failure \
     needs_netd_direct_connect_rule \
     target_init_vendor_lib \
+    target_inputdispatcher_skip_event_key \
     target_ld_shim_libs \
     target_process_sdk_version_override \
     target_surfaceflinger_fod_lib \
@@ -86,6 +87,7 @@ SOONG_CONFIG_lineageQcomVars_uses_qti_camera_device := $(TARGET_USES_QTI_CAMERA_
 BOOTLOADER_MESSAGE_OFFSET ?= 0
 TARGET_ADDITIONAL_GRALLOC_10_USAGE_BITS ?= 0
 TARGET_INIT_VENDOR_LIB ?= vendor_init
+TARGET_INPUTDISPATCHER_SKIP_EVENT_KEY ?= 0
 TARGET_SPECIFIC_CAMERA_PARAMETER_LIBRARY ?= libcamera_parameters
 TARGET_SURFACEFLINGER_FOD_LIB ?= surfaceflinger_fod_lib
 
@@ -93,6 +95,7 @@ TARGET_SURFACEFLINGER_FOD_LIB ?= surfaceflinger_fod_lib
 SOONG_CONFIG_lineageGlobalVars_additional_gralloc_10_usage_bits := $(TARGET_ADDITIONAL_GRALLOC_10_USAGE_BITS)
 SOONG_CONFIG_lineageGlobalVars_bootloader_message_offset := $(BOOTLOADER_MESSAGE_OFFSET)
 SOONG_CONFIG_lineageGlobalVars_target_init_vendor_lib := $(TARGET_INIT_VENDOR_LIB)
+SOONG_CONFIG_lineageGlobalVars_target_inputdispatcher_skip_event_key := $(TARGET_INPUTDISPATCHER_SKIP_EVENT_KEY)
 SOONG_CONFIG_lineageGlobalVars_target_ld_shim_libs := $(subst $(space),:,$(TARGET_LD_SHIM_LIBS))
 SOONG_CONFIG_lineageGlobalVars_target_process_sdk_version_override := $(TARGET_PROCESS_SDK_VERSION_OVERRIDE)
 SOONG_CONFIG_lineageGlobalVars_target_surfaceflinger_fod_lib := $(TARGET_SURFACEFLINGER_FOD_LIB)


### PR DESCRIPTION
Apparently some devices (like davinci, tucana and lot more devices) have an issue with the InputDispatcher while using gestures.
When you swipe up and go over the FOD, the InputDispatcher does not like this at all as you can see here:

W/InputDispatcher( 1383): Still no focused window. Will drop the event in 4996ms
I/InputDispatcher( 1383): Dropped event because the current application is not responding and the user has started interacting with a different application.

Now with these patches you can tell the InputDispatcher skips the FOD (on a lot of Xiaomi devices like tucana the FOD key is 338).
You can see now it skips the FOD and the other errors do not show up anymore:

I InputDispatcher: Intercepted the key 338


Also, the patches are fixing some bugs with the InputDispatcher. Without these the gestures are lagging and applications do crash while using gestures.

The patches are merged in ArrowOS source as you can see on their gerrit [here](https://review.arrowos.net/q/topic:"eleven-inputdispatcher").


I modified the "soong: introduce TARGET_INPUTDISPATCHER_SKIP_EVENT_KEY" patch (android_vendor_cipher) to get it working with CipherOS. You can read this in the commit message.